### PR TITLE
Choose the bump when running a release by hand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,15 @@ on:
       - 'v*'
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version to release, without the leading v. Defaults to the newest entry in CHANGELOG.md.'
-        required: false
+      bump:
+        description: 'How much to bump the version. `auto` reads the conventional commits since the last tag and decides.'
+        type: choice
+        default: auto
+        options:
+          - auto
+          - patch
+          - minor
+          - major
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,6 +21,9 @@ env:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    # a manual run writes the release commit and tag back to the branch
+    permissions:
+      contents: write
     outputs:
       RELEASE_UPLOAD_ID: ${{ steps.create_release.outputs.id }}
       # the Android job uploads by tag rather than by id
@@ -25,27 +34,50 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      # A manual run has no tag to read a version off — GITHUB_REF is then the
-      # branch, and stripping `refs/tags/v` off it leaves it whole, which is how
-      # the changelog step ended up looking for an entry called
-      # `refs/heads/master`.
+        with:
+          # standard-version reads the tags and the commits since the last one
+          # to work out an `auto` bump, and there is nothing to read in a
+          # shallow clone
+          fetch-depth: 0
+
+      # A tag push arrives with the version already decided and written down. A
+      # manual run has neither, so it cuts the release here: standard-version
+      # bumps src-tauri/Cargo.toml — see .versionrc.js, that file is where this
+      # project keeps its version — writes the CHANGELOG entry the next step
+      # goes looking for, commits and tags.
+      #
+      # Pushing with GITHUB_TOKEN does not start another workflow run, so the
+      # `v*` tag this creates cannot set the whole thing going a second time.
+      - name: Cut the release commit and tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          # through the environment rather than inlined into the script: an
+          # input is whatever the person who started the run chose
+          BUMP: ${{ inputs.bump }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [ "$BUMP" = auto ]; then
+            npx -y standard-version@9
+          else
+            npx -y standard-version@9 --release-as "$BUMP"
+          fi
+          git push --follow-tags origin "HEAD:$GITHUB_REF_NAME"
+
       - name: Work out which version is being released
         id: tag_name
-        env:
-          # through the environment rather than inlined: a workflow input is
-          # whatever the person who ran it typed
-          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
           case "$GITHUB_REF" in
+            # a tag push says so itself
             refs/tags/v*) version="${GITHUB_REF#refs/tags/v}" ;;
-            *) version="$INPUT_VERSION" ;;
+            # otherwise it is the tag the step above just wrote
+            *) version=$(git describe --tags --abbrev=0) ;;
           esac
+          version="${version#v}"
           if [ -z "$version" ]; then
-            version=$(sed -nE 's/^## \[?([0-9]+\.[0-9]+\.[0-9]+[^]]*)\]?.*/\1/p' CHANGELOG.md | head -n 1)
-          fi
-          if [ -z "$version" ]; then
-            echo "no version on the ref, in the inputs, or at the top of CHANGELOG.md" >&2
+            echo "no version on the ref and no tag to read one off" >&2
             exit 1
           fi
           echo "releasing $version"
@@ -99,6 +131,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: true
+          # the tag, not the commit the run started from: a manual run bumps
+          # the version after that commit, and the bundles carry it
+          ref: ${{ needs.create-release.outputs.RELEASE_TAG }}
 
       # Tauri v2 links against the 4.1 webkit2gtk, not the 4.0 the v1 template
       # installed, and against the ayatana fork of libappindicator
@@ -172,6 +207,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: true
+          # same as the desktop job: build the tag that is being released
+          ref: ${{ needs.create-release.outputs.RELEASE_TAG }}
 
       - name: Java setup
         uses: actions/setup-java@v5


### PR DESCRIPTION
`workflow_dispatch` had no version of its own. What it had was a fallback that read the newest entry already in `CHANGELOG.md` — enough to stop the "No log entry found for version refs/heads/master" failure, but it could only ever re-release what was already out.

A manual run now cuts the release itself.

## The input

```
bump: auto | patch | minor | major     (default: auto)
```

`auto` means standard-version reads the conventional commits since the last tag and decides. The others force it.

The run then bumps `src-tauri/Cargo.toml` — `.versionrc.js` makes that this project's version file, not `package.json` — writes the CHANGELOG entry the next step goes looking for, commits, tags, and pushes both back to the branch the run was started from. A push made with `GITHUB_TOKEN` starts no workflow run, so the `v*` tag it creates cannot set the whole thing going a second time.

A tag push is unchanged: the version is on the ref, nothing is cut.

## Two things that follow

- The checkout is no longer shallow. There is nothing for `auto` to read in a shallow clone.
- Both build jobs check out the release tag instead of the commit the run started from. On a manual run that commit is one short of the version being released, so the bundles would have carried the old one.

The job also declares `permissions: contents: write`, since it now writes back.

## Testing

`npx standard-version --dry-run --release-as minor` against this tree: bumps `src-tauri/Cargo.toml` from 2.1.0 to 2.2.0 and writes the matching entry, which is what the changelog step then reads. The workflow itself has not been run — the first manual dispatch is the real test, and it will push a commit and a tag.

Worth knowing before that first run: `v2.1.0` points at a commit that is not an ancestor of `master` (fork history), so an `auto` bump currently walks the whole history and writes a very long entry. Re-tagging `v2.1.0` onto the current line, or cutting the first one with an explicit bump, avoids it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
