### PR TITLE
fix(ci): install the project before cutting a release with standard-v…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,25 @@ jobs:
       #
       # Pushing with GITHUB_TOKEN does not start another workflow run, so the
       # `v*` tag this creates cannot set the whole thing going a second time.
+      #
+      # standard-version is configured by .versionrc.js, which pulls in
+      # tauriVersioner.js, which pulls in @tauri-apps/toml — all of it resolved
+      # from the repository, none of it from wherever the CLI itself was
+      # fetched. So the project's own dependencies go in first and the CLI is
+      # run out of them, at the version package.json pins.
+      - name: Node.js setup
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20.x
+      - name: Install pnpm
+        if: github.event_name == 'workflow_dispatch'
+        uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          run_install: |
+            - args: [--no-frozen-lockfile]
+
       - name: Cut the release commit and tag
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -59,9 +78,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if [ "$BUMP" = auto ]; then
-            npx -y standard-version@9
+            pnpm exec standard-version
           else
-            npx -y standard-version@9 --release-as "$BUMP"
+            pnpm exec standard-version --release-as "$BUMP"
           fi
           git push --follow-tags origin "HEAD:$GITHUB_REF_NAME"
 


### PR DESCRIPTION
…ersion

`npx standard-version` brought the CLI and nothing else, and the CLI is the smallest part of what a release here needs: .versionrc.js pulls in tauriVersioner.js, which pulls in @tauri-apps/toml, and all three are resolved from the repository rather than from wherever npx parked the CLI. The run died on `Cannot find module '@tauri-apps/toml'` before it had bumped anything.

The job now installs the project's own dependencies — same node and pnpm setup as the two build jobs — and runs the CLI out of them, at the version package.json pins. Only on a manual run: a tag push cuts nothing and needs none of it.

Checked from a clean clone: `pnpm install` then `standard-version --dry-run --release-as patch` bumps src-tauri/Cargo.toml 2.1.0 -> 2.1.1 and writes the entry the changelog step reads.